### PR TITLE
CustomUserDetails, CustomUserDetailsService 수정

### DIFF
--- a/be/src/main/java/jshop/domain/address/controller/AddressController.java
+++ b/be/src/main/java/jshop/domain/address/controller/AddressController.java
@@ -32,12 +32,12 @@ public class AddressController {
     @ResponseStatus(HttpStatus.CREATED)
     public void saveAddress(@RequestBody @Valid CreateAddressRequest createAddressRequest,
         @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = Optional
+            .ofNullable(userDetails)
+            .orElseThrow(JwtUserNotFoundException::new)
+            .getId();
 
-        User user = Optional
-            .ofNullable(userDetails.getUser())
-            .orElseThrow(JwtUserNotFoundException::new);
-
-        addressService.saveAddress(createAddressRequest, user);
+        addressService.saveAddress(createAddressRequest, userId);
     }
 }
 

--- a/be/src/main/java/jshop/domain/address/service/AddressService.java
+++ b/be/src/main/java/jshop/domain/address/service/AddressService.java
@@ -1,11 +1,14 @@
 package jshop.domain.address.service;
 
 import java.util.Optional;
+import javax.swing.text.html.Option;
 import jshop.domain.address.dto.CreateAddressRequest;
 import jshop.domain.address.entity.Address;
 import jshop.domain.address.repository.AddressRepository;
 import jshop.domain.user.entity.User;
+import jshop.domain.user.repository.UserRepository;
 import jshop.global.exception.security.JwtUserNotFoundException;
+import jshop.global.exception.user.UserIdNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,9 +19,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class AddressService {
 
     private final AddressRepository addressRepository;
+    private final UserRepository userRepository;
 
-    public void saveAddress(CreateAddressRequest createAddressRequest, User user) {
-
+    public void saveAddress(CreateAddressRequest createAddressRequest, Long userId) {
+        Optional<User> optionalUser = userRepository.findById(userId);
+        User user = optionalUser.orElseThrow(UserIdNotFoundException::new);
         Address newAddress = Address.ofCreateAddressRequest(createAddressRequest, user);
         addressRepository.save(newAddress);
     }

--- a/be/src/main/java/jshop/domain/user/controller/UserController.java
+++ b/be/src/main/java/jshop/domain/user/controller/UserController.java
@@ -13,8 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,10 +27,11 @@ public class UserController {
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     public Response<UserInfoResponse> join(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        User user = Optional
-            .ofNullable(userDetails.getUser())
-            .orElseThrow(JwtUserNotFoundException::new);
-        UserInfoResponse userInfoResponse = userService.getUser(user.getId());
+        Long userId = Optional
+            .ofNullable(userDetails)
+            .orElseThrow(JwtUserNotFoundException::new)
+            .getId();
+        UserInfoResponse userInfoResponse = userService.getUser(userId);
 
         return Response
             .<UserInfoResponse>builder().message("유저 정보입니다.").data(userInfoResponse).build();

--- a/be/src/main/java/jshop/global/jwt/dto/CustomUserDetails.java
+++ b/be/src/main/java/jshop/global/jwt/dto/CustomUserDetails.java
@@ -3,14 +3,21 @@ package jshop.global.jwt.dto;
 import java.util.ArrayList;
 import java.util.Collection;
 import jshop.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @RequiredArgsConstructor
+@Builder
+@AllArgsConstructor
 public class CustomUserDetails implements UserDetails {
 
-    private final User user;
+    private Long id;
+    private final String username;
+    private final String password;
+    private final String role;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -19,29 +26,35 @@ public class CustomUserDetails implements UserDetails {
         collection.add(new GrantedAuthority() {
             @Override
             public String getAuthority() {
-                return user.getRole();
+                return role;
             }
         });
 
         return collection;
     }
 
-    public Long getId() {
-        return user.getId();
+    public static CustomUserDetails ofUser(User user) {
+        return CustomUserDetails
+            .builder()
+            .id(user.getId())
+            .username(user.getEmail())
+            .password(user.getPassword())
+            .role(user.getRole())
+            .build();
     }
 
-    public User getUser() {
-        return this.user;
+    public Long getId() {
+        return id;
     }
 
     @Override
     public String getPassword() {
-        return user.getPassword();
+        return password;
     }
 
     @Override
     public String getUsername() {
-        return user.getEmail();
+        return username;
     }
 
     @Override

--- a/be/src/main/java/jshop/global/jwt/service/CustomUserDetailsService.java
+++ b/be/src/main/java/jshop/global/jwt/service/CustomUserDetailsService.java
@@ -23,6 +23,12 @@ public class CustomUserDetailsService implements UserDetailsService {
         User user = optionalUser.orElseThrow(() -> new UsernameNotFoundException(
             "User not found: " + email));
 
-        return new CustomUserDetails(user);
+        return CustomUserDetails
+            .builder()
+            .id(user.getId())
+            .username(user.getEmail())
+            .password(user.getPassword())
+            .role(user.getRole())
+            .build();
     }
 }

--- a/be/src/test/java/jshop/domain/address/controller/AddressControllerTest.java
+++ b/be/src/test/java/jshop/domain/address/controller/AddressControllerTest.java
@@ -50,13 +50,13 @@ public class AddressControllerTest {
     private ArgumentCaptor<CreateAddressRequest> createAddressRequestCaptor;
 
     @Captor
-    private ArgumentCaptor<User> userCaptor;
+    private ArgumentCaptor<Long> userIdCaptor;
 
     @Test
     public void 정상주소추가() throws Exception {
         // given
         User u = getUser();
-        CustomUserDetails customUserDetails = new CustomUserDetails(u);
+        CustomUserDetails customUserDetails = CustomUserDetails.ofUser(u);
 
         UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
         SecurityContext context = SecurityContextHolder.createEmptyContext();
@@ -72,12 +72,13 @@ public class AddressControllerTest {
             .content(requestBody.toString()));
 
         // then
-        verify(addressService, times(1)).saveAddress(createAddressRequestCaptor.capture(), userCaptor.capture());
+        verify(addressService, times(1)).saveAddress(createAddressRequestCaptor.capture(), userIdCaptor.capture());
+
         CreateAddressRequest createAddressRequest = createAddressRequestCaptor.getValue();
-        User user = userCaptor.getValue();
+        Long userId = userIdCaptor.getValue();
 
         perform.andExpect(status().isCreated());
-        assertThat(user).isEqualTo(u);
+        assertThat(userId).isEqualTo(1L);
         assertThat(createAddressRequest.getCity()).isEqualTo("광주시");
     }
 
@@ -112,6 +113,7 @@ public class AddressControllerTest {
     private User getUser() {
         User u = User
             .builder()
+            .id(1L)
             .username("user")
             .email("email@email.com")
             .password("password")

--- a/be/src/test/java/jshop/domain/address/service/AddressServiceTest.java
+++ b/be/src/test/java/jshop/domain/address/service/AddressServiceTest.java
@@ -4,12 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 import jshop.domain.address.dto.CreateAddressRequest;
 import jshop.domain.address.entity.Address;
 import jshop.domain.address.repository.AddressRepository;
 import jshop.domain.user.entity.User;
+import jshop.domain.user.repository.UserRepository;
 import jshop.global.exception.security.JwtUserNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +30,9 @@ public class AddressServiceTest {
     @Mock
     private AddressRepository addressRepository;
 
+    @Mock
+    private UserRepository userRepository;
+
     @Captor
     private ArgumentCaptor<Address> addressCaptor;
 
@@ -36,7 +41,7 @@ public class AddressServiceTest {
         // given
         String city = "광주시";
         User user = User
-            .builder().username("kim").email("test").build();
+            .builder().id(1L).username("kim").email("test").build();
 
         CreateAddressRequest createAddressRequest = CreateAddressRequest
             .builder()
@@ -50,8 +55,9 @@ public class AddressServiceTest {
             .message("문앞에 놔주세요")
             .build();
 
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         // when
-        addressService.saveAddress(createAddressRequest, user);
+        addressService.saveAddress(createAddressRequest, 1L);
 
         // then
         verify(addressRepository, times(1)).save(addressCaptor.capture());

--- a/be/src/test/java/jshop/domain/jwt/dto/CustomUserDetailsTest.java
+++ b/be/src/test/java/jshop/domain/jwt/dto/CustomUserDetailsTest.java
@@ -11,14 +11,16 @@ class CustomUserDetailsTest {
     @Test
     public void username_이메일리턴() {
         // given
-        User user = User.builder()
+        User user = User
+            .builder()
             .username("kim")
             .email("email")
             .password("password")
+            .role("ROLE_USER")
             .build();
 
         // when
-        CustomUserDetails cud = new CustomUserDetails(user);
+        CustomUserDetails cud = CustomUserDetails.ofUser(user);
 
         // then
         assertThat(cud.getUsername()).isEqualTo(user.getEmail());

--- a/be/src/test/java/jshop/integration/security/LoginTest.java
+++ b/be/src/test/java/jshop/integration/security/LoginTest.java
@@ -58,6 +58,7 @@ public class LoginTest {
         BCryptPasswordEncoder bpe = new BCryptPasswordEncoder();
         User u = User
             .builder()
+            .id(1L)
             .username("user")
             .email("user")
             .password(bpe.encode("password"))
@@ -65,7 +66,7 @@ public class LoginTest {
             .build();
 
         System.out.println(userDetailsService);
-        UserDetails userDetails = new CustomUserDetails(u);
+        UserDetails userDetails = CustomUserDetails.ofUser(u);
         when(userDetailsService.loadUserByUsername("user")).thenReturn(userDetails);
         when(userDetailsService.loadUserByUsername(not(ArgumentMatchers.eq("user")))).thenThrow(UsernameNotFoundException.class);
 
@@ -110,13 +111,14 @@ public class LoginTest {
         BCryptPasswordEncoder bpe = new BCryptPasswordEncoder();
         User u = User
             .builder()
+            .id(1L)
             .username("user")
             .email("user")
             .password(bpe.encode("password"))
             .role("ROLE_USER")
             .build();
 
-        UserDetails userDetails = new CustomUserDetails(u);
+        UserDetails userDetails = CustomUserDetails.ofUser(u);
         when(userDetailsService.loadUserByUsername("user")).thenReturn(userDetails);
 
         JSONObject requestBody = new JSONObject();


### PR DESCRIPTION
* 내부에 User 엔티티를 가지고 있다보니 혼동이 될 수 있음
* 내부에 User를 참조 => 필요한 정보 만 저장
* 이와 관련된 컨트롤러, 테스트 로직 수정


## 설명
AddressService.`saveAddress` 에서 인증정보에 포함된 `User` 를 직접 사용.

인증정보에 포함된 `User` 는 영속성 컨텍스트에 의해 관리되지 않는 그냥 객체임. 

추후 문제가 발생소지가 있어 미리 수정.