### PR TITLE
[Refactoring] 서비스 레이어의 인가 로직을 컨트롤러로 분리

### DIFF
--- a/be/src/main/java/jshop/domain/address/controller/AddressController.java
+++ b/be/src/main/java/jshop/domain/address/controller/AddressController.java
@@ -10,6 +10,7 @@ import jshop.global.annotation.CurrentUserId;
 import jshop.global.dto.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,14 +40,16 @@ public class AddressController {
     }
 
     @DeleteMapping("/{id}")
-    public void deleteAddress(@PathVariable("id") Long addressId, @CurrentUserId Long userId) {
-        addressService.deleteAddress(addressId, userId);
+    @PreAuthorize("isAuthenticated() && @addressService.checkAddressOwnership(authentication.principal, #addressId)")
+    public void deleteAddress(@PathVariable("id") @P("addressId") Long addressId) {
+        addressService.deleteAddress(addressId);
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("isAuthenticated() && @addressService.checkAddressOwnership(authentication.principal, #addressId)")
     public void updateAddress(@RequestBody @Valid UpdateAddressRequest updateAddressRequest,
-        @PathVariable("id") Long addressId, @CurrentUserId Long userId) {
-        addressService.updateAddress(updateAddressRequest, addressId, userId);
+        @PathVariable("id") Long addressId) {
+        addressService.updateAddress(updateAddressRequest, addressId);
     }
 }
 

--- a/be/src/main/java/jshop/domain/category/controller/CategoryController.java
+++ b/be/src/main/java/jshop/domain/category/controller/CategoryController.java
@@ -8,6 +8,7 @@ import jshop.domain.category.service.CategoryService;
 import jshop.global.annotation.CurrentUserRole;
 import jshop.global.dto.Response;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,10 +29,9 @@ public class CategoryController {
             .<List<CategoryResponse>>builder().data(categoryService.getAllCategories()).build();
     }
 
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @Secured("ROLE_ADMIN")
     @PostMapping
-    public void createCategory(@RequestBody @Valid CreateCategoryRequest createCategoryRequest,
-        @CurrentUserRole String userRole) {
-        categoryService.createCategory(createCategoryRequest, userRole);
+    public void createCategory(@RequestBody @Valid CreateCategoryRequest createCategoryRequest) {
+        categoryService.createCategory(createCategoryRequest);
     }
 }

--- a/be/src/main/java/jshop/domain/category/service/CategoryService.java
+++ b/be/src/main/java/jshop/domain/category/service/CategoryService.java
@@ -25,7 +25,8 @@ public class CategoryService {
     }
 
     @Transactional
-    public void createCategory(CreateCategoryRequest createCategoryRequest, String userRole) {
+    public void createCategory(CreateCategoryRequest createCategoryRequest) {
+        
         if (categoryRepository.existsByName(createCategoryRequest.getName())) {
             log.error(ErrorCode.ALREADY_EXISTS_CATEGORY.getLogMessage(), createCategoryRequest.getName());
             throw JshopException.of(ErrorCode.ALREADY_EXISTS_CATEGORY);

--- a/be/src/main/java/jshop/domain/product/service/ProductService.java
+++ b/be/src/main/java/jshop/domain/product/service/ProductService.java
@@ -173,7 +173,7 @@ public class ProductService {
         if (product.getOwner().getId() == userId) {
             return true;
         }
-
+        log.error(ErrorCode.UNAUTHORIZED.getLogMessage(), "Product", productId, userId);
         throw JshopException.of(ErrorCode.UNAUTHORIZED);
     }
 
@@ -192,7 +192,7 @@ public class ProductService {
         if (product.getOwner().getId() == userId) {
             return true;
         }
-
+        log.error(ErrorCode.UNAUTHORIZED.getLogMessage(), "ProductDetail", detailId, userId);
         throw JshopException.of(ErrorCode.UNAUTHORIZED);
     }
 }

--- a/be/src/main/java/jshop/global/config/SecurityConfig.java
+++ b/be/src/main/java/jshop/global/config/SecurityConfig.java
@@ -21,7 +21,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
-@EnableGlobalMethodSecurity(prePostEnabled = true)
+@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
 public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;

--- a/be/src/test/java/jshop/domain/address/controller/AddressControllerTest.java
+++ b/be/src/test/java/jshop/domain/address/controller/AddressControllerTest.java
@@ -1,7 +1,8 @@
 package jshop.domain.address.controller;
 
 
-import static jshop.utils.SecurityContextUtil.userSecurityContext;
+import static jshop.utils.MockSecurityContextUtil.getSecurityContextMockUserId;
+import static jshop.utils.MockSecurityContextUtil.mockUserSecurityContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.times;
@@ -34,7 +35,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @WebMvcTest(AddressController.class)
 @Import({TestSecurityConfig.class, GlobalExceptionHandler.class})
-@DisplayName("AddressController 단위테스트")
+@DisplayName("[단위 테스트] AddressController 단위테스트")
 public class AddressControllerTest {
 
     @MockBean
@@ -58,9 +59,8 @@ public class AddressControllerTest {
     @Captor
     private ArgumentCaptor<Long> addressIdCaptor;
 
-
     @Nested
-    @DisplayName("주소 생성 파라미터 검증")
+    @DisplayName("주소 생성 리퀘스트 바디 검증")
     class CreateAddress {
 
         private static final JSONObject createAddressRequestJson = new JSONObject();
@@ -82,7 +82,7 @@ public class AddressControllerTest {
             // when
             ResultActions perform = mockMvc.perform(MockMvcRequestBuilders
                 .post("/api/addresses")
-                .with(userSecurityContext())
+                .with(mockUserSecurityContext())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(createAddressRequestJson.toString()));
 
@@ -94,7 +94,7 @@ public class AddressControllerTest {
             Long userId = userIdCaptor.getValue();
 
             perform.andExpect(status().isOk());
-            assertThat(userId).isEqualTo(1L);
+            assertThat(userId).isEqualTo(getSecurityContextMockUserId());
             assertAll("createAddressRequest 검증",
                 () -> assertThat(createAddressRequest.getReceiverName()).isEqualTo("김재현"),
                 () -> assertThat(createAddressRequest.getReceiverNumber()).isEqualTo("010-1234-1234"),
@@ -122,11 +122,11 @@ public class AddressControllerTest {
         }
 
         @Test
-        @DisplayName("주소정보가 없다면 주소를 생성할 수 없음")
+        @DisplayName("인증 정보가 있어도 주소정보가 없다면 주소를 생성할 수 없음")
         public void createAddress_noRequest() throws Exception {
             // when
             ResultActions perform = mockMvc.perform(
-                MockMvcRequestBuilders.post("/api/addresses").with(userSecurityContext()));
+                MockMvcRequestBuilders.post("/api/addresses").with(mockUserSecurityContext()));
 
             // then
             perform
@@ -156,18 +156,17 @@ public class AddressControllerTest {
     }
 
     @Nested
-    @DisplayName("주소 삭제 테스트")
+    @DisplayName("주소 삭제 패스 파라미터 검증")
     class DeleteAddress {
 
         @Test
         @DisplayName("주소 삭제시 PathVariable로 주소의 ID를 받는다")
         public void deleteAddress_success() throws Exception {
             // when
-            ResultActions perform = mockMvc.perform(
-                MockMvcRequestBuilders.delete("/api/addresses/1").with(userSecurityContext()));
+            mockMvc.perform(MockMvcRequestBuilders.delete("/api/addresses/1").with(mockUserSecurityContext()));
 
             // then
-            verify(addressService, times(1)).deleteAddress(1L, 1L);
+            verify(addressService, times(1)).deleteAddress(1L);
         }
 
         @Test
@@ -175,7 +174,7 @@ public class AddressControllerTest {
         public void deleteAddress_noAddressId() throws Exception {
             // when
             ResultActions perform = mockMvc.perform(
-                MockMvcRequestBuilders.delete("/api/addresses").with(userSecurityContext()));
+                MockMvcRequestBuilders.delete("/api/addresses").with(mockUserSecurityContext()));
 
             // then
             perform.andExpect(status().isMethodNotAllowed());
@@ -183,7 +182,7 @@ public class AddressControllerTest {
     }
 
     @Nested
-    @DisplayName("주소 갱신 테스트")
+    @DisplayName("주소 갱신 리퀘스트 바디 검증")
     class UpdateAddress {
 
         private static final JSONObject updateAddressRequestJson = new JSONObject();
@@ -205,13 +204,13 @@ public class AddressControllerTest {
             // when
             ResultActions perform = mockMvc.perform(MockMvcRequestBuilders
                 .put("/api/addresses/1")
-                .with(userSecurityContext())
+                .with(mockUserSecurityContext())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(updateAddressRequestJson.toString()));
 
             // then
             verify(addressService, times(1)).updateAddress(updateAddressRequestArgumentCaptor.capture(),
-                addressIdCaptor.capture(), userIdCaptor.capture());
+                addressIdCaptor.capture());
         }
 
         @Test
@@ -219,7 +218,7 @@ public class AddressControllerTest {
         public void updateAddress_noAddressId() throws Exception {
             // when
             ResultActions perform = mockMvc.perform(
-                MockMvcRequestBuilders.put("/api/addresses").with(userSecurityContext()));
+                MockMvcRequestBuilders.put("/api/addresses").with(mockUserSecurityContext()));
 
             // then
             perform.andExpect(status().isMethodNotAllowed());
@@ -230,7 +229,7 @@ public class AddressControllerTest {
         public void updateAddress_noRequestBody() throws Exception {
             // when
             ResultActions perform = mockMvc.perform(
-                MockMvcRequestBuilders.put("/api/addresses/1").with(userSecurityContext()));
+                MockMvcRequestBuilders.put("/api/addresses/1").with(mockUserSecurityContext()));
 
             // then
             perform.andExpect(status().isBadRequest());

--- a/be/src/test/java/jshop/domain/address/controller/AddressControllerTest.java
+++ b/be/src/test/java/jshop/domain/address/controller/AddressControllerTest.java
@@ -15,7 +15,8 @@ import jshop.domain.address.dto.UpdateAddressRequest;
 import jshop.domain.address.service.AddressService;
 import jshop.global.common.ErrorCode;
 import jshop.global.controller.GlobalExceptionHandler;
-import jshop.utils.TestSecurityConfig;
+import jshop.utils.config.TestSecurityConfig;
+import jshop.utils.config.TestSecurityConfigWithoutMethodSecurity;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -34,7 +35,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @WebMvcTest(AddressController.class)
-@Import({TestSecurityConfig.class, GlobalExceptionHandler.class})
+@Import({TestSecurityConfigWithoutMethodSecurity.class, GlobalExceptionHandler.class})
 @DisplayName("[단위 테스트] AddressController 단위테스트")
 public class AddressControllerTest {
 

--- a/be/src/test/java/jshop/domain/address/dto/AddressInfoResponseTest.java
+++ b/be/src/test/java/jshop/domain/address/dto/AddressInfoResponseTest.java
@@ -8,7 +8,7 @@ import jshop.domain.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("AddressInfoResponse DTO 테스트")
+@DisplayName("[단위 테스트] ]AddressInfoResponse")
 class AddressInfoResponseTest {
 
     @Test

--- a/be/src/test/java/jshop/domain/address/dto/CreateAddressRequestTest.java
+++ b/be/src/test/java/jshop/domain/address/dto/CreateAddressRequestTest.java
@@ -8,7 +8,7 @@ import jshop.domain.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("CreaateAddressRequest DTO 테스트")
+@DisplayName("[단위 테스트] CreaateAddressRequest")
 class CreateAddressRequestTest {
 
     @Test

--- a/be/src/test/java/jshop/domain/address/entity/AddressTest.java
+++ b/be/src/test/java/jshop/domain/address/entity/AddressTest.java
@@ -8,7 +8,7 @@ import jshop.domain.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("Address Entity 테스트")
+@DisplayName("[단위 테스트] Address")
 class AddressTest {
 
     @Test

--- a/be/src/test/java/jshop/domain/address/service/AddressServiceTest.java
+++ b/be/src/test/java/jshop/domain/address/service/AddressServiceTest.java
@@ -27,7 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("AddressService Service 테스트")
+@DisplayName("[단위 테스트] AddressService")
 public class AddressServiceTest {
 
     @InjectMocks
@@ -101,44 +101,17 @@ public class AddressServiceTest {
             when(addressRepository.findById(1L)).thenReturn(Optional.of(address));
 
             // then
-            addressService.deleteAddress(1L, 1L);
+            addressService.deleteAddress(1L);
             assertThat(address.getUser()).isNull();
             assertThat(address.getIsDeleted()).isTrue();
         }
 
         @Test
-        @DisplayName("주소 ID로 찾을 수 없다면 ADDRESSID_NOT_FOUND 예외를 던짐")
-        public void deleteAddress_addressNotFound() {
-            // given
-            User user = User
-                .builder().username("kim").id(1L).build();
-
-            // when
-            when(addressRepository.findById(1L)).thenReturn(Optional.empty());
-
+        @DisplayName("존재하지 않는 주소를 삭제하면 예외를 던짐")
+        public void deleteAddress_noAddress() {
             // then
-            JshopException jshopException = assertThrows(JshopException.class,
-                () -> addressService.deleteAddress(1L, 1L));
+            JshopException jshopException = assertThrows(JshopException.class, () -> addressService.deleteAddress(1L));
             assertThat(jshopException.getErrorCode()).isEqualTo(ErrorCode.ADDRESSID_NOT_FOUND);
-        }
-
-        @Test
-        @DisplayName("유저는 자신의 주소가 아니라면 삭제할 수 없음")
-        public void deleteAddress_userNotOwner() {
-            // given
-            User user = User
-                .builder().username("kim").id(1L).build();
-
-            Address address = Address
-                .builder().id(1L).city("광주시").user(user).build();
-
-            // when
-            when(addressRepository.findById(1L)).thenReturn(Optional.of(address));
-
-            // then
-            JshopException jshopException = assertThrows(JshopException.class,
-                () -> addressService.deleteAddress(1L, 2L));
-            assertThat(jshopException.getErrorCode()).isEqualTo(ErrorCode.UNAUTHORIZED);
         }
     }
 
@@ -163,50 +136,22 @@ public class AddressServiceTest {
             when(addressRepository.findById(1L)).thenReturn(Optional.of(address));
 
             // then
-            addressService.updateAddress(updateAddressRequest, 1L, 1L);
+            addressService.updateAddress(updateAddressRequest, 1L);
             assertThat(address.getCity()).isEqualTo("서울특별시");
 
         }
 
         @Test
-        @DisplayName("주소 ID로 찾을 수 없다면 ADDRESSID_NOT_FOUND 예외를 던짐")
-        public void updateAddress_addressNotFound() {
+        @DisplayName("존재하지 않는 주소를 갱신하면 예외를 던짐")
+        public void deleteAddress_noAddress() {
             // given
-            User user = User
-                .builder().username("kim").id(1L).build();
-
             UpdateAddressRequest updateAddressRequest = UpdateAddressRequest
-                .builder().build();
-
-            // when
-            when(addressRepository.findById(1L)).thenReturn(Optional.empty());
+                .builder().city("서울특별시").build();
 
             // then
             JshopException jshopException = assertThrows(JshopException.class,
-                () -> addressService.updateAddress(updateAddressRequest, 1L, 1L));
+                () -> addressService.updateAddress(updateAddressRequest, 1L));
             assertThat(jshopException.getErrorCode()).isEqualTo(ErrorCode.ADDRESSID_NOT_FOUND);
-        }
-
-        @Test
-        @DisplayName("유저는 자신의 주소가 아니라면 갱신할 수 없음")
-        public void updateAddress_userNotOwner() {
-            // given
-            User user = User
-                .builder().username("kim").id(1L).build();
-
-            UpdateAddressRequest updateAddressRequest = UpdateAddressRequest
-                .builder().build();
-
-            Address address = Address
-                .builder().id(1L).city("광주시").user(user).build();
-
-            // when
-            when(addressRepository.findById(1L)).thenReturn(Optional.of(address));
-
-            // then
-            JshopException jshopException = assertThrows(JshopException.class,
-                () -> addressService.updateAddress(updateAddressRequest, 1L, 2L));
-            assertThat(jshopException.getErrorCode()).isEqualTo(ErrorCode.UNAUTHORIZED);
         }
     }
 }

--- a/be/src/test/java/jshop/domain/category/controller/CategoryControllerTest.java
+++ b/be/src/test/java/jshop/domain/category/controller/CategoryControllerTest.java
@@ -1,6 +1,6 @@
 package jshop.domain.category.controller;
 
-import static jshop.utils.SecurityContextUtil.userSecurityContext;
+import static jshop.utils.MockSecurityContextUtil.mockUserSecurityContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -63,7 +63,7 @@ class CategoryControllerTest {
             // when
             ResultActions perform = mockMvc.perform(MockMvcRequestBuilders
                 .post("/api/categories")
-                .with(userSecurityContext())
+                .with(mockUserSecurityContext())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(createCategoryRequestJson.toString()));
 

--- a/be/src/test/java/jshop/domain/category/controller/CategoryControllerTest.java
+++ b/be/src/test/java/jshop/domain/category/controller/CategoryControllerTest.java
@@ -1,6 +1,5 @@
 package jshop.domain.category.controller;
 
-import static jshop.utils.MockSecurityContextUtil.mockUserSecurityContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -9,9 +8,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import jshop.domain.category.dto.CreateCategoryRequest;
 import jshop.domain.category.service.CategoryService;
-import jshop.global.common.ErrorCode;
 import jshop.global.controller.GlobalExceptionHandler;
-import jshop.utils.TestSecurityConfig;
+import jshop.utils.config.TestSecurityConfig;
+import jshop.utils.config.TestSecurityConfigWithoutMethodSecurity;
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -24,14 +23,15 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 
 @WebMvcTest(CategoryController.class)
-@Import({TestSecurityConfig.class, GlobalExceptionHandler.class})
-@DisplayName("CategoryController Controller 테스트")
+@Import({TestSecurityConfigWithoutMethodSecurity.class, GlobalExceptionHandler.class})
+@DisplayName("[단위 테스트] CategoryController")
 class CategoryControllerTest {
 
     @MockBean
@@ -55,6 +55,7 @@ class CategoryControllerTest {
 
         @Test
         @DisplayName("카테고리 생성 서비스로 요청과 권한을 넘겨줌")
+        @WithMockUser(roles = {"ADMIN"})
         public void createCategory_success() throws Exception {
             // given
             JSONObject createCategoryRequestJson = new JSONObject();
@@ -63,36 +64,13 @@ class CategoryControllerTest {
             // when
             ResultActions perform = mockMvc.perform(MockMvcRequestBuilders
                 .post("/api/categories")
-                .with(mockUserSecurityContext())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(createCategoryRequestJson.toString()));
 
             // then
             perform.andExpect(status().isOk());
-            verify(categoryService, times(1)).createCategory(createCategoryRequestArgumentCaptor.capture(),
-                userRoleArgumentCaptor.capture());
-            assertThat(userRoleArgumentCaptor.getValue()).isEqualTo("ROLE_USER");
+            verify(categoryService, times(1)).createCategory(createCategoryRequestArgumentCaptor.capture());
             assertThat(createCategoryRequestArgumentCaptor.getValue().getName()).isEqualTo("전자기기");
-        }
-
-        @Test
-        @DisplayName("권한이 없다면 401을 내려줌")
-        public void createCategory_401() throws Exception {
-            // given
-            JSONObject createCategoryRequestJson = new JSONObject();
-            createCategoryRequestJson.put("name", "전자기기");
-
-            // when
-
-            ResultActions perform = mockMvc.perform(MockMvcRequestBuilders
-                .post("/api/categories")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(createCategoryRequestJson.toString()));
-
-            // then
-            perform
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.errorCode").value(ErrorCode.JWT_USER_NOT_FOUND.getCode()));
         }
     }
 

--- a/be/src/test/java/jshop/domain/category/dto/CategoryResponseTest.java
+++ b/be/src/test/java/jshop/domain/category/dto/CategoryResponseTest.java
@@ -7,7 +7,7 @@ import jshop.domain.category.entity.Category;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("CategoryResponse DTO 테스트")
+@DisplayName("[단위 테스트] CategoryResponse")
 class CategoryResponseTest {
 
     @Test

--- a/be/src/test/java/jshop/domain/category/entity/CategoryTest.java
+++ b/be/src/test/java/jshop/domain/category/entity/CategoryTest.java
@@ -6,7 +6,7 @@ import jshop.domain.category.dto.CreateCategoryRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("Category 엔티티 테스트")
+@DisplayName("[단위 테스트] Category")
 class CategoryTest {
 
     @Test

--- a/be/src/test/java/jshop/domain/category/service/CategoryServiceTest.java
+++ b/be/src/test/java/jshop/domain/category/service/CategoryServiceTest.java
@@ -22,7 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("CategoryService Service 테스트")
+@DisplayName("[단위 테스트] CategoryService")
 class CategoryServiceTest {
 
     @InjectMocks
@@ -45,8 +45,8 @@ class CategoryServiceTest {
             CreateCategoryRequest categoryRequest = CreateCategoryRequest
                 .builder().name("전자제품").build();
 
-            // when
-            categoryService.createCategory(categoryRequest, "ROLE_USER");
+            // whenㅁ
+            categoryService.createCategory(categoryRequest);
 
             // then
             verify(categoryRepository, times(1)).save(categoryCaptor.capture());
@@ -64,15 +64,13 @@ class CategoryServiceTest {
                 .builder().name("전자제품").build();
 
             // when
-            categoryService.createCategory(categoryRequest1, "ROLE_USER");
+            categoryService.createCategory(categoryRequest1);
             when(categoryRepository.existsByName(categoryRequest2.getName())).thenReturn(true);
 
             // then
             JshopException jshopException = assertThrows(JshopException.class,
-                () -> categoryService.createCategory(categoryRequest2, "ROLE_USER"));
+                () -> categoryService.createCategory(categoryRequest2));
             assertThat(jshopException.getErrorCode()).isEqualTo(ErrorCode.ALREADY_EXISTS_CATEGORY);
         }
     }
-
-
 }

--- a/be/src/test/java/jshop/domain/product/controller/ProductControllerTest.java
+++ b/be/src/test/java/jshop/domain/product/controller/ProductControllerTest.java
@@ -13,7 +13,7 @@ import jshop.domain.product.dto.CreateProductDetailRequest;
 import jshop.domain.product.service.ProductService;
 import jshop.global.common.ErrorCode;
 import jshop.global.controller.GlobalExceptionHandler;
-import jshop.utils.TestSecurityConfig;
+import jshop.utils.config.TestSecurityConfig;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;

--- a/be/src/test/java/jshop/domain/product/controller/ProductControllerTest.java
+++ b/be/src/test/java/jshop/domain/product/controller/ProductControllerTest.java
@@ -1,6 +1,6 @@
 package jshop.domain.product.controller;
 
-import static jshop.utils.SecurityContextUtil.userSecurityContext;
+import static jshop.utils.MockSecurityContextUtil.mockUserSecurityContext;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -65,7 +65,7 @@ class ProductControllerTest {
             // when
             ResultActions perform = mockMvc.perform(MockMvcRequestBuilders
                 .post("/api/products")
-                .with(userSecurityContext())
+                .with(mockUserSecurityContext())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody.toString()));
 
@@ -83,7 +83,7 @@ class ProductControllerTest {
         public void getOwnProducts() throws Exception {
             // when
             ResultActions perform = mockMvc.perform(
-                MockMvcRequestBuilders.get("/api/products?page=0&size=10").with(userSecurityContext()));
+                MockMvcRequestBuilders.get("/api/products?page=0&size=10").with(mockUserSecurityContext()));
 
             // then
             perform.andExpect(status().isOk());
@@ -95,7 +95,7 @@ class ProductControllerTest {
         public void getOwnProducts_defaultValue() throws Exception {
             // when
             ResultActions perform = mockMvc.perform(
-                MockMvcRequestBuilders.get("/api/products").with(userSecurityContext()));
+                MockMvcRequestBuilders.get("/api/products").with(mockUserSecurityContext()));
 
             // then
             perform.andExpect(status().isOk());
@@ -129,7 +129,7 @@ class ProductControllerTest {
             // when
             ResultActions perform = mockMvc.perform(MockMvcRequestBuilders
                 .post("/api/products/1/details")
-                .with(userSecurityContext())
+                .with(mockUserSecurityContext())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody.toString()));
             // then
@@ -145,7 +145,7 @@ class ProductControllerTest {
             // when
             ResultActions perform = mockMvc.perform(MockMvcRequestBuilders
                 .post("/api/products/1/details")
-                .with(userSecurityContext())
+                .with(mockUserSecurityContext())
                 .contentType(MediaType.APPLICATION_JSON));
 
             // then
@@ -169,7 +169,7 @@ class ProductControllerTest {
             // when
             ResultActions perform = mockMvc.perform(MockMvcRequestBuilders
                 .post("/api/products/1/details")
-                .with(userSecurityContext())
+                .with(mockUserSecurityContext())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody.toString()));
 

--- a/be/src/test/java/jshop/domain/product/controller/SearchControllerTest.java
+++ b/be/src/test/java/jshop/domain/product/controller/SearchControllerTest.java
@@ -1,6 +1,6 @@
 package jshop.domain.product.controller;
 
-import static jshop.utils.SecurityContextUtil.userSecurityContext;
+import static jshop.utils.MockSecurityContextUtil.mockUserSecurityContext;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -56,7 +56,7 @@ public class SearchControllerTest {
             // given
             ResultActions perform = mockMvc.perform(MockMvcRequestBuilders
                 .get("/api/search?cursor=123&size=20&query=아이폰")
-                .with(userSecurityContext())
+                .with(mockUserSecurityContext())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(createAddressRequestJson.toString()));
             // when
@@ -71,7 +71,7 @@ public class SearchControllerTest {
             // given
             ResultActions perform = mockMvc.perform(MockMvcRequestBuilders
                 .get("/api/search?query=아이폰")
-                .with(userSecurityContext())
+                .with(mockUserSecurityContext())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(createAddressRequestJson.toString()));
             // when
@@ -86,7 +86,7 @@ public class SearchControllerTest {
             // given
             ResultActions perform = mockMvc.perform(MockMvcRequestBuilders
                 .get("/api/search")
-                .with(userSecurityContext())
+                .with(mockUserSecurityContext())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(createAddressRequestJson.toString()));
             // when

--- a/be/src/test/java/jshop/domain/product/controller/SearchControllerTest.java
+++ b/be/src/test/java/jshop/domain/product/controller/SearchControllerTest.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import jshop.domain.address.dto.CreateAddressRequest;
 import jshop.domain.product.service.ProductService;
 import jshop.global.controller.GlobalExceptionHandler;
-import jshop.utils.TestSecurityConfig;
+import jshop.utils.config.TestSecurityConfig;
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/be/src/test/java/jshop/domain/user/controller/AccountControllerTest.java
+++ b/be/src/test/java/jshop/domain/user/controller/AccountControllerTest.java
@@ -11,7 +11,7 @@ import jshop.domain.user.dto.UserType;
 import jshop.domain.user.service.UserService;
 import jshop.global.controller.GlobalExceptionHandler;
 import jshop.utils.DtoBuilder;
-import jshop.utils.TestSecurityConfig;
+import jshop.utils.config.TestSecurityConfig;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;

--- a/be/src/test/java/jshop/domain/user/controller/UserControllerTest.java
+++ b/be/src/test/java/jshop/domain/user/controller/UserControllerTest.java
@@ -8,7 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import jshop.domain.user.dto.UpdateUserRequest;
 import jshop.domain.user.service.UserService;
 import jshop.global.controller.GlobalExceptionHandler;
-import jshop.utils.TestSecurityConfig;
+import jshop.utils.config.TestSecurityConfig;
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/be/src/test/java/jshop/domain/user/controller/UserControllerTest.java
+++ b/be/src/test/java/jshop/domain/user/controller/UserControllerTest.java
@@ -1,6 +1,6 @@
 package jshop.domain.user.controller;
 
-import static jshop.utils.SecurityContextUtil.userSecurityContext;
+import static jshop.utils.MockSecurityContextUtil.mockUserSecurityContext;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -46,7 +46,7 @@ class UserControllerTest {
         public void getUserInfo_success() throws Exception {
             // when
             ResultActions perform = mockMvc.perform(
-                MockMvcRequestBuilders.get("/api/users").with(userSecurityContext()));
+                MockMvcRequestBuilders.get("/api/users").with(mockUserSecurityContext()));
 
             // then
             verify(userService, times(1)).getUser(1L);
@@ -82,7 +82,7 @@ class UserControllerTest {
             // when
             ResultActions perform = mockMvc.perform(MockMvcRequestBuilders
                 .patch("/api/users")
-                .with(userSecurityContext())
+                .with(mockUserSecurityContext())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody.toString()));
 

--- a/be/src/test/java/jshop/global/annotation/CurrentUserIdArgumentResolverTest.java
+++ b/be/src/test/java/jshop/global/annotation/CurrentUserIdArgumentResolverTest.java
@@ -1,6 +1,6 @@
 package jshop.global.annotation;
 
-import static jshop.utils.SecurityContextUtil.userSecurityContext;
+import static jshop.utils.MockSecurityContextUtil.mockUserSecurityContext;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -34,7 +34,8 @@ class CurrentUserIdArgumentResolverTest {
     @DisplayName("JWT에 principal이 있을때 컨트롤러 파라미터에서 userId 제공")
     public void getUserId() throws Exception {
         // when
-        ResultActions perform = mockMvc.perform(MockMvcRequestBuilders.get("/api/userid").with(userSecurityContext()));
+        ResultActions perform = mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/userid").with(mockUserSecurityContext()));
 
         // then
         perform.andExpect(status().isOk()).andExpect(jsonPath("$.userid").value(1L));

--- a/be/src/test/java/jshop/global/annotation/CurrentUserIdArgumentResolverTest.java
+++ b/be/src/test/java/jshop/global/annotation/CurrentUserIdArgumentResolverTest.java
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import jshop.global.common.ErrorCode;
 import jshop.global.controller.GlobalExceptionHandler;
 import jshop.utils.MockController;
-import jshop.utils.TestSecurityConfig;
+import jshop.utils.config.TestSecurityConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/be/src/test/java/jshop/global/annotation/CurrentUserRoleArgumentResolverTest.java
+++ b/be/src/test/java/jshop/global/annotation/CurrentUserRoleArgumentResolverTest.java
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import jshop.global.common.ErrorCode;
 import jshop.global.controller.GlobalExceptionHandler;
 import jshop.utils.MockController;
-import jshop.utils.TestSecurityConfig;
+import jshop.utils.config.TestSecurityConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/be/src/test/java/jshop/global/annotation/CurrentUserRoleArgumentResolverTest.java
+++ b/be/src/test/java/jshop/global/annotation/CurrentUserRoleArgumentResolverTest.java
@@ -1,6 +1,6 @@
 package jshop.global.annotation;
 
-import static jshop.utils.SecurityContextUtil.userSecurityContext;
+import static jshop.utils.MockSecurityContextUtil.mockUserSecurityContext;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -35,7 +35,7 @@ class CurrentUserRoleArgumentResolverTest {
     public void getUserId() throws Exception {
         // when
         ResultActions perform = mockMvc.perform(
-            MockMvcRequestBuilders.get("/api/userrole").with(userSecurityContext()));
+            MockMvcRequestBuilders.get("/api/userrole").with(mockUserSecurityContext()));
 
         // then
         perform.andExpect(status().isOk()).andExpect(jsonPath("$.userRole").value("ROLE_USER"));

--- a/be/src/test/java/jshop/integration/domain/address/AddressControllerIntegrationTest.java
+++ b/be/src/test/java/jshop/integration/domain/address/AddressControllerIntegrationTest.java
@@ -39,7 +39,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-@DisplayName("통합테스트 AddressController")
+@DisplayName("[통합 테스트] AddressController")
 public class AddressControllerIntegrationTest {
 
     @Autowired

--- a/be/src/test/java/jshop/integration/domain/product/ProductServiceIntegrationTest.java
+++ b/be/src/test/java/jshop/integration/domain/product/ProductServiceIntegrationTest.java
@@ -1,7 +1,7 @@
 package jshop.integration.domain.product;
 
 
-import static jshop.utils.SecurityContextUtil.userSecurityContext;
+import static jshop.utils.MockSecurityContextUtil.mockUserSecurityContext;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import jshop.domain.product.service.ProductService;
@@ -48,7 +48,7 @@ public class ProductServiceIntegrationTest {
             { "price" : 1000}
             """;
         mockMvc.perform(post("/api/products/1/details")
-            .with(userSecurityContext())
+            .with(mockUserSecurityContext())
             .contentType(MediaType.APPLICATION_JSON)
             .content(str));
     }

--- a/be/src/test/java/jshop/utils/MockSecurityContextUtil.java
+++ b/be/src/test/java/jshop/utils/MockSecurityContextUtil.java
@@ -9,19 +9,19 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
-public class SecurityContextUtil {
+public class MockSecurityContextUtil {
 
-    public static RequestPostProcessor userSecurityContext() {
+    private static Long userId = 1L;
+    private static String username = "username";
+    private static String password = "password";
+    private static String role = "ROLE_USER";
+    private static String email = "email@email.com";
+
+    public static RequestPostProcessor mockUserSecurityContext() {
         return request -> {
 
             User u = User
-                .builder()
-                .id(1L)
-                .username("user")
-                .email("email@email.com")
-                .password("password")
-                .role("ROLE_USER")
-                .build();
+                .builder().id(userId).username(username).email(email).password(password).role(role).build();
             CustomUserDetails customUserDetails = CustomUserDetails.ofUser(u);
             UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(customUserDetails,
                 null, customUserDetails.getAuthorities());
@@ -32,5 +32,9 @@ public class SecurityContextUtil {
 
             return SecurityMockMvcRequestPostProcessors.securityContext(context).postProcessRequest(request);
         };
+    }
+
+    public static Long getSecurityContextMockUserId() {
+        return userId;
     }
 }

--- a/be/src/test/java/jshop/utils/config/TestSecurityConfig.java
+++ b/be/src/test/java/jshop/utils/config/TestSecurityConfig.java
@@ -1,13 +1,15 @@
-package jshop.utils;
+package jshop.utils.config;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
 @EnableWebSecurity
 @TestConfiguration
+@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
 public class TestSecurityConfig {
 
     @Bean

--- a/be/src/test/java/jshop/utils/config/TestSecurityConfigWithoutMethodSecurity.java
+++ b/be/src/test/java/jshop/utils/config/TestSecurityConfigWithoutMethodSecurity.java
@@ -1,0 +1,18 @@
+package jshop.utils.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@TestConfiguration
+public class TestSecurityConfigWithoutMethodSecurity {
+
+    @Bean
+    protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(auth -> auth.disable());
+        return http.build();
+    }
+}


### PR DESCRIPTION
## 설명
* `@PreAuthorize` 를 사용해 컨트롤러 레이어에서 자원 인가 작업 수행
* 서비스 레이어는 비즈니스 로직만 수행
* 컨트롤러에서 인가가 실패하면 서비스 로직도 수행하지 않음.
* 테스트또한 서비스 레이어의 단위테스트에서 인가 부분 삭제
